### PR TITLE
big refactor on where/how card and score related logic is handled

### DIFF
--- a/src/components/CardTest.js
+++ b/src/components/CardTest.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useReducer } from "react";
 import { initialiseDeck, drawCard } from "../utils/api-utils";
 import Card from "../classes/Card";
 import Hand from "./Hand";
@@ -8,62 +8,127 @@ import Double from "./buttons/Double";
 import Hit from "./buttons/Hit";
 import Split from "./buttons/Split";
 import Stand from "./buttons/Stand";
-import Button from "@mui/material/Button";
 import ChatBox from "./ChatBox";
 
+
 const CardTest = () => {
+  //initState for dealer and player
+  const initialHand = {
+    cards: [],
+    score: {
+      highTotal: 0,
+      lowTotal: 0
+    },
+    bust: false,
+    turn: false
+  }
   const [deckId, setDeckId] = useState("");
-  const [playerCards, setPlayerCards] = useState([]);
-  const [dealerCards, setDealerCards] = useState([]);
-  const [dealersTurn, setDealersTurn] = useState(false);
+
+  //State for dealer vars - add dealers turn here later
+  const [dealerVars, dealerDispatch] = useReducer((state, action) => {
+    switch(action.type) {
+      case "addCard": {
+        const newScore = updateScore(action.payload.value, state.score);
+        return ({
+          ...state,
+          cards: [...state.cards, action.payload],
+          score: state.cards.length === 1 && !state.turn ? state.score : newScore,
+          bust: newScore.lowTotal > 21 ? true : false
+        })
+      }
+      case "setTurn": {
+        return ({
+          ...state,
+          turn: true,
+          score: updateScore(state.cards[state.cards.length-1].value, state.score)
+        })
+      }
+      default: {
+        throw new Error("Invalid action for Dealer");
+      }
+    }
+  },{...initialHand})
+
+  //state for playerVars
+  const [playerVars, playerDispatch] = useReducer((state, action) => {
+    switch(action.type) {
+      case "addCard": {
+        const newScore = updateScore(action.payload.value, state.score);
+        return ({
+          ...state,
+          cards: [...state.cards, action.payload],
+          score: newScore,
+          bust: newScore.lowTotal > 21 ? true : false
+        })
+      }
+      default: {
+        throw new Error("Invalid action for Player");
+      }
+    }
+  }, {...initialHand})
 
   //initialise a new 6 decks and set the id in state
   useEffect(() => {
     initialiseDeck(6).then(setDeckId);
   }, []);
 
-  //INPUT: cards: Array of Objects receieved from API
-  //       dealer: Boolean - true if adding to dealers hand
-  function addToHand(cards, dealer) {
-    let cardsToAdd = [];
-    //create a new Card from data receieved and push to array of Cards to add to state
-    cards.forEach((card) => {
-      cardsToAdd.push(new Card(card.suit, card.value, card.image));
-    });
-
-    //add new cards to players cards paying respect to what cards they already have
-    if (dealer) {
-      setDealerCards([...dealerCards, ...cardsToAdd]);
+  function updateScore(value, curScore) {
+    let newScore = {...curScore}
+    if (value === "ACE") {
+      newScore.lowTotal += 1;
+      newScore.highTotal += newScore.highTotal + 11 > 21 ? 1 : 11;
+    } else if (isNaN(value) === true) {
+      // face cards
+      newScore.lowTotal += 10;
+      newScore.highTotal += 10;
     } else {
-      setPlayerCards([...playerCards, ...cardsToAdd]);
+      // number cards
+      value = parseInt(value);
+      newScore.lowTotal += value;
+      newScore.highTotal += value;
     }
-  }
+    return newScore;
+}
 
   //draw 2 cards for player then for dealer
   function dealCards() {
-    drawCard(deckId, 2).then((cards) => addToHand(cards, false));
-    drawCard(deckId, 2).then((cards) => addToHand(cards, true));
+    drawCard(deckId, 1).then(addCardToPlayer);
+    drawCard(deckId, 1).then(addCardToDealer);
+    drawCard(deckId, 1).then(addCardToPlayer);
+    drawCard(deckId, 1).then(addCardToDealer);
   }
+
+  //===================
+  //wrappers to interact with dispatches
+  function addCardToDealer(card) {
+    const newCard = new Card(card[0].suit, card[0].value, card[0].image);
+    dealerDispatch({
+      type: "addCard",
+      payload: newCard
+    });
+  }
+
+  function addCardToPlayer(card) {
+    const newCard = new Card(card[0].suit, card[0].value, card[0].image);
+    playerDispatch({
+      type: "addCard",
+      payload: newCard
+    });
+  }
+  //================
 
   return (
     <>
       <p>deckId: {deckId}</p>
-      {/*buttons call drawCard to make API request and then pass data to addToHand*/}
-      {/* <button onClick={() => drawCard(deckId, 2).then(addToHand)}>
-        Draw 2 Cards
-      </button>
-      <button onClick={() => drawCard(deckId, 1).then(addToHand)}>
-        Draw 1 Card
-      </button>
-      <button onClick={dealCards}>Deal</button> */}
-      <Hand dealer dealersTurn={dealersTurn} cards={dealerCards} />
-      <Hand cards={playerCards} />
+
+      <Hand dealer dealersTurn={dealerVars.turn} cards={dealerVars.cards} score={dealerVars.score} bust={dealerVars.bust}/>
+      <Hand cards={playerVars.cards} score={playerVars.score} bust={playerVars.bust}/>
 
       <div>
         <Bet />
         <Split />
-        <Stand />
-        <Hit buttonFunc={() => drawCard(deckId, 1).then(addToHand)}/>
+        <Stand buttonFunc={() => dealerDispatch({type: "setTurn"})}/>
+        <Hit buttonFunc={() => drawCard(deckId, 1).then(addCardToPlayer)}/>
         <Double />
         <Deal buttonFunc={dealCards} />
       </div>

--- a/src/components/Hand.js
+++ b/src/components/Hand.js
@@ -1,51 +1,7 @@
-import { useEffect, useState } from "react";
 import faceDownCard from "./../images/face-down-card.jpeg";
 
 const Hand = (props) => {
-  const { dealer, cards, dealersTurn } = props;
-  const [score, setScore] = useState({
-    highTotal: 0,
-    lowTotal: 0,
-  });
-  const [bust, setBust] = useState(false);
-
-  //Originally calculateScore
-  useEffect(() => {
-    // calculates score for aces
-    let newScore = {
-      highTotal: 0,
-      lowTotal: 0,
-    };
-    for (
-      let i = 0;
-      i < (dealer && !dealersTurn && cards.length === 2 ? 1 : cards.length);
-      i++
-    ) {
-      let value = cards[i].value;
-      if (value === "ACE") {
-        newScore.lowTotal += 1;
-        newScore.highTotal += newScore.highTotal + 11 > 21 ? 1 : 11;
-      } else if (isNaN(value) === true) {
-        // face cards
-        newScore.lowTotal += 10;
-        newScore.highTotal += 10;
-      } else {
-        // number cards
-        value = parseInt(value);
-        newScore.lowTotal += value;
-        newScore.highTotal += value;
-      }
-    }
-    setScore(newScore);
-  }, [cards, dealer, dealersTurn]);
-
-  useEffect(() => {
-    if (score.lowTotal > 21) {
-      setBust(true);
-    } else {
-      setBust(false);
-    }
-  }, [score])
+  const { dealer, cards, dealersTurn, score, bust } = props;
 
   return (
     <div>
@@ -77,7 +33,7 @@ const Hand = (props) => {
       {cards.length > 0 &&
       <h2>
         Points:{" "}
-        {score.highTotal > 1 &&
+        {score.highTotal >= 1 &&
           (score.highTotal > 21 ? score.lowTotal : score.highTotal)}
       </h2>}
       {bust && <h2>Bust!</h2>}

--- a/src/components/buttons/Stand.js
+++ b/src/components/buttons/Stand.js
@@ -1,8 +1,9 @@
 import Button from "@mui/material/Button";
 
-const Stand = () => {
+const Stand = (props) => {
+  const {buttonFunc} = props;
   return (
-    <Button variant="contained" size="large" color="error">
+    <Button variant="contained" size="large" color="error" onClick={buttonFunc}>
       Stand
     </Button>
   );


### PR DESCRIPTION
- card Test now has playerVars and dealerVars which hold cards/score/bust status etc -> implemented with reducer
- all state removed from Hand.js and moved to CardTest as per above
- This makes it way easier to manipulate cards/query player/dealer statuses - previously wasnt possible to have all the data required for dealer AI to work without 'hacky' bad practices.
- Also fixes the issue with dealing cards - can now deal in the 'correct' order and this is implemented.
- Stand button now sets it to dealers turn and they flip over their face down card